### PR TITLE
Add missing ending bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.0.1
 
-- Transparent image is stronger than ever, with END bytes.
+- Transparent image is stronger than ever, with 3 more ending bytes.
 
 ## 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+- Transparent image is stronger than ever, with END bytes.
+
 ## 2.0.0
 
 - Maximum Stability Unlocked.

--- a/lib/transparent_image.dart
+++ b/lib/transparent_image.dart
@@ -67,4 +67,7 @@ final Uint8List kTransparentImage = new Uint8List.fromList(<int>[
   0x4E,
   0x44,
   0xAE,
+  0x42,
+  0x60,
+  0x82,
 ]);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: transparent_image
 description: A transparent image in Dart code, represented as a Uint8List.
-version: 2.0.0
+version: 2.0.1
 homepage: https://github.com/brianegan/transparent_image
 
 environment:


### PR DESCRIPTION
Discovered through testing on web that the image was missing three bytes at the end in accordance with the .png file format

Compared with a 1x1 transparent .png, now matches and the test passes.
<img width="482" alt="Screenshot 2023-02-17 at 12 23 44" src="https://user-images.githubusercontent.com/6655696/219662507-cf5566e7-ce30-4a38-9a55-66440adc3de3.png">

This PR adds those and bumps the version to `2.0.1`.